### PR TITLE
Fix for callback being a global variable

### DIFF
--- a/lib/easyrss.js
+++ b/lib/easyrss.js
@@ -20,11 +20,12 @@
 var http = require('http')
   , xml = require('libxmljs')
   , parseURL = require('url').parse
-  , options = {};
+
+
 
 // The main "meat" of this module - parses an rss feed and triggers
 // the callback when done.
-var easyParser = function(callback) {
+var easyParser = function(callback,options) {
   var parser = new xml.SaxParser(function(cb) {
     var articles = Array();
     var current_element = false;
@@ -129,10 +130,11 @@ exports.parseFile = function(file, cb) {
  */
 
 exports.parseURL = function(url, opts) {
-  if (typeof opts == 'function') {
-    options = { cb: opts };
-  } else {
-    options = opts;
+  var options={};
+  if(typeof opts=="function"){
+    options.cb = opts;
+  } else { 
+    options=opts;
   }
 
   get_rss(url);
@@ -156,7 +158,7 @@ exports.parseURL = function(url, opts) {
           var body = ''; 
           response.addListener('data', function (chunk) { body += chunk; });
           response.addListener('end', function() {
-            easyParser(options.cb).parseString(body);
+            easyParser(options.cb,options).parseString(body);
           });
           break;
         // redirect status returned


### PR DESCRIPTION
Hi, while attempting to use easyrss we saw an odd behavior while attempting to make 3 simultaneous requests for RSS feeds from URLs, the callback for the last request made was called for all three requests. Apparently easyrss was using a global variable to hold the callback. We have fixed this and tested it, so now a number of simultaneous requests will work correctly. 
