### PR TITLE
Fixed issue where the article title could be set to the text of another e

### DIFF
--- a/lib/easyrss.js
+++ b/lib/easyrss.js
@@ -91,7 +91,7 @@ var easyParser = function(callback,options) {
             if(current_attrs['href']) {
               articles[article_count][current_element] = current_attrs['href'];
             }
-            else
+            else if(!prefix) /* Some namespaces use the title element, such as MediaRSS, i.e., media:title */
               articles[article_count][current_element] = current_chars.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
             break;
         }


### PR DESCRIPTION
Fixed issue where the article title could be set to the text of another element in a different namespace also named title (e.g., MediaRSS uses media:title).
