### PR TITLE
Implement request for parseURL

### DIFF
--- a/lib/easyrss.js
+++ b/lib/easyrss.js
@@ -17,7 +17,7 @@
 
 **********************************************************************/
 
-var http = require('http')
+var request = require('request')
   , xml = require('libxmljs')
   , parseURL = require('url').parse
 
@@ -154,55 +154,11 @@ exports.parseURL = function(url, opts) {
     options=opts;
   }
 
-  get_rss(url);
-  function get_rss(url) {
-    var parts = parseURL(url);
-
-    // set the default port to 80
-    if(!parts.port) { parts.port = 80; }
-
-    var redirection_level = 0;
-    var client = http.createClient(parts.port, parts.hostname);
-
-    // include search terms in pathname if present
-
-    var address = parts.pathname + (parts.search==undefined ? "" : parts.search);
-    var request = client.request('GET', address, {'host': parts.hostname});
-
-    request.addListener('response', function (response) {
-      //sys.puts('STATUS: ' + response.statusCode);
-      //sys.puts('HEADERS: ' + JSON.stringify(response.headers));
-      // check to see the type of status
-      switch(response.statusCode) {
-        // check for ALL OK
-        case 200:
-          var body = ''; 
-          response.addListener('data', function (chunk) { body += chunk; });
-          response.addListener('end', function() {
-            easyParser(options.cb,options).parseString(body);
-          });
-          break;
-        // redirect status returned
-        case 301:
-        case 302:
-          if(redirection_level > 10) {
-            console.log("too many redirects");
-          } else {
-            console.log("redirect to "+response.headers.location);
-            get_rss(response.headers.location);
-          }
-          break;
-        default:
-          /*
-          response.setEncoding('utf8');
-          response.addListener('data', function (chunk) {
-            //sys.puts('BODY: ' + chunk);
-          });
-          */
-          break;
-	    }	  
-	  });
-	  
-    request.end();	
-  }
+  request(url, function(error, response, body) {
+    if (!error) { 
+      easyParser(options.cb,options).parseString(body);
+    }
+  });
 };
+
+

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "libxmljs": "*"
+    , "request": "2.1.1"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
I needed the ability to parse RSS feeds over HTTPS and in the process of trying to modify it I ended up just replacing http with mikeal's request library, which allows as little as a url string or the ability to pass an option hash for as much configuration as you need.  It also cleans up all the redirection logic going on.
